### PR TITLE
Initial setup: datasets SPA + daily split pipeline

### DIFF
--- a/.github/workflows/daily-split.yml
+++ b/.github/workflows/daily-split.yml
@@ -1,0 +1,86 @@
+name: Daily split & release
+
+on:
+  schedule:
+    # 03:00 JST = 18:00 UTC (Starrydata DB snapshot is 02:00 JST)
+    - cron: "0 18 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: daily-split
+  cancel-in-progress: false
+
+env:
+  DRIVE_FILE_ID: 1py40fDLkTW2kcGx-ie7xHxG2Iqisfcuk
+
+jobs:
+  split:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r scripts/requirements.txt
+
+      - name: Download dataset from Google Drive
+        run: |
+          gdown "$DRIVE_FILE_ID" -O starrydata_dataset.zip
+          ls -lh starrydata_dataset.zip
+
+      - name: Split into per-project files
+        run: python scripts/split.py --zip starrydata_dataset.zip --out ./out
+
+      - name: Determine release tag
+        id: tag
+        run: |
+          DATE=$(date -u +%Y%m%d)
+          echo "tag=data-${DATE}" >> "$GITHUB_OUTPUT"
+          echo "name=Starrydata split ${DATE}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish dated release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          NAME="${{ steps.tag.outputs.name }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release delete "$TAG" --yes --cleanup-tag
+          fi
+          gh release create "$TAG" \
+            --title "$NAME" \
+            --notes "Auto-generated split of starrydata_dataset.zip ($(cat out/manifest.json | python -c 'import json,sys; print(json.load(sys.stdin)[\"db_snapshot\"])'))" \
+            out/data/*.csv.gz out/manifest.json
+
+      - name: Update 'latest' release pointer
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view latest >/dev/null 2>&1; then
+            gh release delete latest --yes --cleanup-tag
+          fi
+          gh release create latest \
+            --title "Latest split" \
+            --notes "Mirror of ${{ steps.tag.outputs.tag }}. URLs of the form /releases/latest/download/<file> always point here." \
+            out/data/*.csv.gz out/manifest.json
+
+      - name: Commit manifest.json to docs/
+        run: |
+          mkdir -p docs
+          cp out/manifest.json docs/manifest.json
+          if git diff --quiet docs/manifest.json; then
+            echo "No manifest changes"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/manifest.json
+          git commit -m "chore: update manifest.json ($(date -u +%Y-%m-%d))"
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.venv/
+_out/
+out/
+*.zip
+__pycache__/
+.DS_Store

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Starrydata Datasets — daily per-project CSV downloads</title>
+<style>
+  :root {
+    --bg-0: #030812;
+    --bg-1: #0d1b3e;
+    --panel: rgba(30, 41, 59, 0.8);
+    --panel-hi: rgba(30, 41, 59, 1);
+    --border: rgba(148, 163, 184, 0.18);
+    --border-hi: rgba(96, 165, 250, 0.45);
+    --text: #e2e8f0;
+    --muted: #94a3b8;
+    --accent: #60a5fa;
+    --accent-hi: #93c5fd;
+    --good: #34d399;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body { background: radial-gradient(ellipse at 30% 30%, var(--bg-1) 0%, #060e24 40%, var(--bg-0) 100%); min-height: 100vh; color: var(--text); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Hiragino Kaku Gothic ProN", sans-serif; }
+  body { padding: 40px 20px 60px; }
+  .wrap { max-width: 1100px; margin: 0 auto; }
+  header { text-align: center; margin-bottom: 36px; }
+  header h1 { font-size: 28px; font-weight: 700; letter-spacing: 0.5px; }
+  header p { color: var(--muted); margin-top: 8px; font-size: 14px; }
+  header a { color: var(--accent); text-decoration: none; }
+  header a:hover { color: var(--accent-hi); }
+  .meta-row { display: flex; gap: 24px; justify-content: center; margin-top: 18px; flex-wrap: wrap; font-size: 13px; color: var(--muted); }
+  .meta-row b { color: var(--text); font-weight: 600; }
+  .totals { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 28px; }
+  tr.all-data-row td { background: rgba(96, 165, 250, 0.08); }
+  tr.all-data-row:hover td { background: rgba(96, 165, 250, 0.14); }
+  tr.all-data-row td.pname { color: var(--accent); }
+  .totals .stat { background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 14px; text-align: center; }
+  .totals .stat .n { font-size: 22px; font-weight: 700; color: var(--accent); }
+  .totals .stat .l { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 1px; margin-top: 4px; }
+  table { width: 100%; border-collapse: collapse; background: var(--panel); border-radius: 8px; overflow: hidden; }
+  th, td { padding: 12px 14px; text-align: center; font-size: 13px; border: none; vertical-align: middle; }
+  th:first-child, td:first-child { text-align: left; }
+  th:nth-child(n+2):nth-child(-n+5), td:nth-child(n+2):nth-child(-n+5) { text-align: right; font-variant-numeric: tabular-nums; }
+  th { background: rgba(0,0,0,0.25); color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: 1px; font-weight: 600; }
+  tr:hover td { background: var(--panel-hi); }
+  .pname { font-weight: 600; color: var(--text); }
+  .dl { display: flex; align-items: center; justify-content: center; gap: 4px; padding: 6px 10px; background: rgba(96, 165, 250, 0.12); border: 1px solid rgba(96, 165, 250, 0.3); border-radius: 4px; color: var(--accent); text-decoration: none; font-size: 11px; font-weight: 600; transition: all 0.15s ease; white-space: nowrap; }
+  .dl:hover { background: rgba(96, 165, 250, 0.25); border-color: var(--accent); color: var(--accent-hi); }
+  .dl .sz { font-weight: 400; color: var(--muted); font-size: 10px; }
+  .dl:hover .sz { color: var(--accent-hi); }
+  .dl-cell { min-width: 280px; }
+  .dl-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; }
+  footer { text-align: center; color: var(--muted); font-size: 12px; margin-top: 28px; }
+  footer a { color: var(--accent); text-decoration: none; }
+  .err { background: rgba(239, 68, 68, 0.15); border: 1px solid rgba(239, 68, 68, 0.4); padding: 16px; border-radius: 8px; color: #fca5a5; margin: 20px 0; }
+  .loading { text-align: center; color: var(--muted); padding: 40px; font-size: 14px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <h1>Starrydata Datasets</h1>
+    <p>Per-project CSV splits of the <a href="https://starrydata.nims.go.jp/" target="_blank" rel="noopener">Starrydata2</a> dataset, refreshed daily.</p>
+    <div class="meta-row">
+      <span>DB snapshot: <b id="snapshot">—</b></span>
+      <span>Files generated: <b id="generated">—</b></span>
+      <span><a id="repo-link" href="#" target="_blank" rel="noopener">GitHub repository</a></span>
+    </div>
+  </header>
+
+  <div id="totals" class="totals"></div>
+  <div id="content" class="loading">Loading…</div>
+
+  <footer>
+    Source: <a href="https://drive.google.com/drive/folders/1OVMP7j61CJFwLtJ-qZFef9ko40Othayh" target="_blank" rel="noopener">official Starrydata Google Drive</a> ·
+    Counts API: <a href="https://starrydata.github.io/json/counts.json" target="_blank" rel="noopener">starrydata.github.io</a> ·
+    CSV format: gzipped (open with pandas <code>pd.read_csv(..., compression='gzip')</code> or Excel after decompression)
+  </footer>
+</div>
+
+<script>
+  // ─── Configuration ────────────────────────────────────────────────
+  // Set after the repo is created. Both the GitHub release URLs and the
+  // header link in the page derive from these two values.
+  const REPO_OWNER = "starrydata";
+  const REPO_NAME = "starrydata_datasets";
+
+  const COUNTS_URL = "https://starrydata.github.io/json/counts.json";
+  const MANIFEST_URL = "./manifest.json";
+  const RELEASE_BASE = `https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/latest/download`;
+  const REPO_URL = `https://github.com/${REPO_OWNER}/${REPO_NAME}`;
+
+  document.getElementById("repo-link").href = REPO_URL;
+
+  // ─── Helpers ──────────────────────────────────────────────────────
+  const fmtNum = (n) => n.toLocaleString("en-US");
+  const fmtBytes = (b) => {
+    if (b == null) return "";
+    if (b < 1024) return `${b} B`;
+    if (b < 1024 * 1024) return `${(b / 1024).toFixed(0)} KB`;
+    return `${(b / 1024 / 1024).toFixed(1)} MB`;
+  };
+  const TZ_LIST = [
+    { tz: "UTC", label: "UTC" },
+    { tz: "Asia/Tokyo", label: "JST" },
+  ];
+  const fmtInTZ = (d, tz) => {
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      timeZone: tz, year: "numeric", month: "2-digit", day: "2-digit",
+      hour: "2-digit", minute: "2-digit", hour12: false,
+    }).formatToParts(d);
+    const g = (t) => parts.find((p) => p.type === t).value;
+    return `${g("year")}-${g("month")}-${g("day")} ${g("hour")}:${g("minute")}`;
+  };
+  const fmtDate = (input) => {
+    if (!input) return "—";
+    // Accept both ISO ("2026-06-25T05:41:04+00:00")
+    // and snapshot strings ("2026-06-25 02:00:01 UTC+0900 (JST)").
+    const normalized = String(input).replace(
+      /UTC([+-])(\d{2})(\d{2}).*/, (_, s, h, m) => `${s}${h}:${m}`
+    );
+    const d = new Date(normalized);
+    if (isNaN(d)) return input;
+    return TZ_LIST.map(({ tz, label }) => `${fmtInTZ(d, tz)} ${label}`).join(" · ");
+  };
+
+  // ─── Render ───────────────────────────────────────────────────────
+  function allDlButton(kind, manifest) {
+    const meta = manifest?.all_data?.[kind];
+    if (!meta) return `<span class="dl" style="opacity:0.3" title="not yet built">all_${kind}</span>`;
+    const url = `${RELEASE_BASE}/${meta.filename}`;
+    return `<a class="dl" href="${url}" title="${meta.rows.toLocaleString()} rows, sha256:${meta.sha256.slice(0,12)}…">all_${kind}<span class="sz">${fmtBytes(meta.bytes)}</span></a>`;
+  }
+
+  function allDataRow(counts, manifest) {
+    return `
+      <tr class="all-data-row">
+        <td class="pname">All projects (whole dataset)</td>
+        <td>${fmtNum(counts.papers ?? 0)}</td>
+        <td>${fmtNum(counts.figures ?? 0)}</td>
+        <td>${fmtNum(counts.samples ?? 0)}</td>
+        <td>${fmtNum(counts.curves ?? 0)}</td>
+        <td class="dl-cell"><div class="dl-grid">${allDlButton("papers", manifest)}${allDlButton("samples", manifest)}${allDlButton("curves", manifest)}</div></td>
+      </tr>
+    `;
+  }
+
+  function renderTotals(counts) {
+    const html = ["papers", "figures", "samples", "curves"].map((k) =>
+      `<div class="stat"><div class="n">${fmtNum(counts[k] ?? 0)}</div><div class="l">${k}</div></div>`
+    ).join("");
+    document.getElementById("totals").innerHTML = html;
+  }
+
+  function dlButton(project, kind, manifest) {
+    const proj = manifest?.projects?.[project];
+    const meta = proj?.[kind];
+    if (!meta) return `<span class="dl" style="opacity:0.3" title="not yet built">${kind}</span>`;
+    const url = `${RELEASE_BASE}/${meta.filename}`;
+    return `<a class="dl" href="${url}" title="${meta.rows.toLocaleString()} rows, sha256:${meta.sha256.slice(0,12)}…">${kind}<span class="sz">${fmtBytes(meta.bytes)}</span></a>`;
+  }
+
+  function renderTable(counts, manifest) {
+    // Sort by curves desc, but keep Battery-family projects adjacent
+    // (anchored to the largest battery's natural position).
+    const isBattery = (n) => /Battery/.test(n);
+    const all = Object.entries(counts.projects ?? {});
+    const batteryCurves = all.filter(([n]) => isBattery(n)).map(([, c]) => c.curves ?? 0);
+    const batteryAnchor = batteryCurves.length ? Math.max(...batteryCurves) : -Infinity;
+    const keyOf = ([name, c]) => isBattery(name) ? batteryAnchor : (c.curves ?? 0);
+    const projects = all.sort((a, b) => {
+      const diff = keyOf(b) - keyOf(a);
+      return diff !== 0 ? diff : (b[1].curves ?? 0) - (a[1].curves ?? 0);
+    });
+
+    const rows = projects.map(([name, c]) => `
+      <tr>
+        <td class="pname">${name}</td>
+        <td>${fmtNum(c.papers ?? 0)}</td>
+        <td>${fmtNum(c.figures ?? 0)}</td>
+        <td>${fmtNum(c.samples ?? 0)}</td>
+        <td>${fmtNum(c.curves ?? 0)}</td>
+        <td class="dl-cell"><div class="dl-grid">${dlButton(name, "papers", manifest)}${dlButton(name, "samples", manifest)}${dlButton(name, "curves", manifest)}</div></td>
+      </tr>
+    `).join("");
+
+    document.getElementById("content").outerHTML = `
+      <table>
+        <thead>
+          <tr>
+            <th>Project</th><th>Papers</th><th>Figures</th><th>Samples</th><th>Curves</th><th>Download</th>
+          </tr>
+        </thead>
+        <tbody>${allDataRow(counts, manifest)}${rows}</tbody>
+      </table>
+    `;
+  }
+
+  async function fetchJSON(url) {
+    const r = await fetch(url, { cache: "no-cache" });
+    if (!r.ok) throw new Error(`${url} → HTTP ${r.status}`);
+    return r.json();
+  }
+
+  (async function () {
+    try {
+      const [counts, manifest] = await Promise.all([
+        fetchJSON(COUNTS_URL),
+        fetchJSON(MANIFEST_URL).catch(() => ({ projects: {} })),
+      ]);
+      renderTotals(counts);
+      renderTable(counts, manifest);
+      document.getElementById("snapshot").textContent = fmtDate(manifest.db_snapshot);
+      document.getElementById("generated").textContent = fmtDate(manifest.generated_at);
+    } catch (e) {
+      document.getElementById("content").outerHTML =
+        `<div class="err">Failed to load: ${e.message}</div>`;
+    }
+  })();
+</script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -37,12 +37,27 @@
   .totals .stat .n { font-size: 22px; font-weight: 700; color: var(--accent); }
   .totals .stat .l { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 1px; margin-top: 4px; }
   table { width: 100%; border-collapse: collapse; background: var(--panel); border-radius: 8px; overflow: hidden; }
-  th, td { padding: 12px 14px; text-align: center; font-size: 13px; border: none; vertical-align: middle; }
-  th:first-child, td:first-child { text-align: left; }
-  th:nth-child(n+2):nth-child(-n+5), td:nth-child(n+2):nth-child(-n+5) { text-align: right; font-variant-numeric: tabular-nums; }
+  th, td { padding: 12px 14px; font-size: 13px; border: none; vertical-align: middle; text-align: left; }
   th { background: rgba(0,0,0,0.25); color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: 1px; font-weight: 600; }
   tr:hover td { background: var(--panel-hi); }
+  .dl-table th, .dl-table td { text-align: center; }
+  .dl-table th:first-child, .dl-table td:first-child { text-align: left; }
+  .dl-table th:nth-child(n+2):nth-child(-n+5), .dl-table td:nth-child(n+2):nth-child(-n+5) { text-align: right; font-variant-numeric: tabular-nums; }
   .pname { font-weight: 600; color: var(--text); }
+  .section-block { margin-top: 36px; }
+  .section-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 1.5px; color: var(--muted); margin-bottom: 12px; padding-left: 4px; }
+  .repos-table td:nth-child(n+2) { color: var(--muted); }
+  .repos-table a { color: var(--accent); text-decoration: none; font-weight: 600; }
+  .repos-table a:hover { color: var(--accent-hi); }
+  .changelog-box { background: var(--panel); border-radius: 8px; padding: 4px 18px 18px; }
+  .changelog-box summary { cursor: pointer; padding: 12px 0; font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 1.5px; font-weight: 600; user-select: none; }
+  .changelog-box summary:hover { color: var(--text); }
+  .changelog-entry { margin-top: 14px; }
+  .changelog-entry h3 { font-size: 13px; color: var(--accent); font-weight: 600; margin-bottom: 6px; letter-spacing: 0.3px; }
+  .changelog-entry ul { list-style: disc; margin-left: 22px; color: var(--muted); font-size: 13px; line-height: 1.75; }
+  .changelog-entry ul a { color: var(--accent); text-decoration: none; }
+  .changelog-entry ul a:hover { text-decoration: underline; }
+  .changelog-entry code { background: rgba(96, 165, 250, 0.12); padding: 1px 6px; border-radius: 3px; font-size: 12px; }
   .dl { display: flex; align-items: center; justify-content: center; gap: 4px; padding: 6px 10px; background: rgba(96, 165, 250, 0.12); border: 1px solid rgba(96, 165, 250, 0.3); border-radius: 4px; color: var(--accent); text-decoration: none; font-size: 11px; font-weight: 600; transition: all 0.15s ease; white-space: nowrap; }
   .dl:hover { background: rgba(96, 165, 250, 0.25); border-color: var(--accent); color: var(--accent-hi); }
   .dl .sz { font-weight: 400; color: var(--muted); font-size: 10px; }
@@ -69,6 +84,93 @@
 
   <div id="totals" class="totals"></div>
   <div id="content" class="loading">Loading…</div>
+
+  <section class="section-block">
+    <div class="section-label">Dataset Repositories</div>
+    <table class="repos-table">
+      <thead>
+        <tr>
+          <th>Repository</th>
+          <th>Description</th>
+          <th>Update Schedule</th>
+          <th>Period</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><a href="https://drive.google.com/drive/folders/1OVMP7j61CJFwLtJ-qZFef9ko40Othayh" target="_blank" rel="noopener">Google Drive</a></td>
+          <td>Latest dataset only</td>
+          <td>Twice daily at 00:00 and 12:00</td>
+          <td>from 2024/06/13</td>
+        </tr>
+        <tr>
+          <td><a href="https://figshare.com/projects/Starrydata_datasets/155129" target="_blank" rel="noopener">Figshare</a></td>
+          <td>Past datasets</td>
+          <td>Daily until 2024/06/06, then monthly</td>
+          <td>from 2022/12/22</td>
+        </tr>
+        <tr>
+          <td><a href="https://github.com/starrydata/starrydata_datasets" target="_blank" rel="noopener">Github</a></td>
+          <td>Past datasets</td>
+          <td>As needed</td>
+          <td>from 2019/7/11 until 2022/12/22</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="section-block">
+    <details class="changelog-box" open>
+      <summary>Changelog</summary>
+      <div class="changelog-entry">
+        <h3>2025/08/22</h3>
+        <ul><li>Add <code>figure_name</code> field to curve dataset.</li></ul>
+      </div>
+      <div class="changelog-entry">
+        <h3>2024/07/04</h3>
+        <ul><li>Excluded datasets with the data type "calculation" in the descriptor from the sample dataset and curve dataset. As of 2024/07/01 12:00:01 UTC+0900 (JST), there were <a href="https://github.com/starrydata/notebook/blob/0ab26b17a8046fe480b3649d9faad325688b61e2/check_sample_datatype/check_sample_datatype.ipynb" target="_blank" rel="noopener">346 samples</a>.</li></ul>
+      </div>
+      <div class="changelog-entry">
+        <h3>2024/06/26</h3>
+        <ul>
+          <li>Changed dataset file name prefix from "all" to "starrydata". For example, <code>all_curves.csv</code> is now <code>starrydata_curves.csv</code>.</li>
+          <li>Changed the file extension of the paper dataset from JSON to CSV for availability.</li>
+          <li>Reduced the columns in the paper dataset to only those necessary for citation, reducing the file size from 400MB to about 50MB.</li>
+          <li>Added <code>project_names</code> and <code>created_at</code> to the paper dataset.</li>
+        </ul>
+      </div>
+      <div class="changelog-entry">
+        <h3>2024/06/13</h3>
+        <ul><li>The latest datasets are now uploaded to Google Drive.</li></ul>
+      </div>
+      <div class="changelog-entry">
+        <h3>2024/06/06</h3>
+        <ul>
+          <li>Fixed the character corruption issue when users open <code>all_samples.csv</code> in certain applications, such as Excel, by adding a BOM.</li>
+          <li>The upload schedule to Figshare has been changed from daily to monthly.</li>
+        </ul>
+      </div>
+      <div class="changelog-entry">
+        <h3>2024/05/22</h3>
+        <ul><li>Fixed the incorrect timestamp format in the dataset. For example, corrected <code>"2024-05-17 00:00:01 JST+0900"</code> to <code>"2024-05-17 00:00:01 GMT+0900 (JST)"</code>.</li></ul>
+      </div>
+      <div class="changelog-entry">
+        <h3>2024/05/21</h3>
+        <ul>
+          <li>The values in the XY value list were originally strings enclosed in double quotations. These double quotations were removed for easier analysis.</li>
+          <li>e.g. <code>["299.8597", "324.8683"]</code> → <code>[299.8597, 324.8683]</code></li>
+        </ul>
+      </div>
+      <div class="changelog-entry">
+        <h3>2024/05/16</h3>
+        <ul><li>Added <code>updated_at</code>, <code>created_at</code>, and <code>composition_details</code> to <code>all_samples.csv</code>.</li></ul>
+      </div>
+      <div class="changelog-entry">
+        <h3>2022/12/22</h3>
+        <ul><li>The dataset location was changed from this GitHub repository to <a href="https://figshare.com/projects/Starrydata_datasets/155129" target="_blank" rel="noopener">Figshare</a>.</li></ul>
+      </div>
+    </details>
+  </section>
 
   <footer>
     Source: <a href="https://drive.google.com/drive/folders/1OVMP7j61CJFwLtJ-qZFef9ko40Othayh" target="_blank" rel="noopener">official Starrydata Google Drive</a> ·
@@ -184,7 +286,7 @@
     `).join("");
 
     document.getElementById("content").outerHTML = `
-      <table>
+      <table class="dl-table">
         <thead>
           <tr>
             <th>Project</th><th>Papers</th><th>Figures</th><th>Samples</th><th>Curves</th><th>Download</th>

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,0 +1,287 @@
+{
+  "generated_at": "2026-06-25T06:31:24.914433+00:00",
+  "db_snapshot": "2026-06-25 02:00:01 UTC+0900 (JST)",
+  "source_zip": "starrydata_dataset.zip",
+  "all_data": {
+    "papers": {
+      "filename": "all_papers.csv.gz",
+      "rows": 56403,
+      "bytes": 9440039,
+      "sha256": "37c1cf68feb9163408e1a85d6fe0bb1c1c6e2deb150ab56d33175c4c4dd1f11b"
+    },
+    "samples": {
+      "filename": "all_samples.csv.gz",
+      "rows": 105022,
+      "bytes": 4667528,
+      "sha256": "663912b937f2e2c0cee6bbc8b6de6237a38670b145be471eee6f2d1805a3e287"
+    },
+    "curves": {
+      "filename": "all_curves.csv.gz",
+      "rows": 233462,
+      "bytes": 43380495,
+      "sha256": "8ad45682fd0f58a0bcbd2a72ab900f42e327ba3cbb6a897eda347e66afcd3974"
+    }
+  },
+  "projects": {
+    "AirBatteryMaterials": {
+      "papers": {
+        "filename": "AirBatteryMaterials_papers.csv.gz",
+        "rows": 45,
+        "bytes": 13487,
+        "sha256": "e96a357efbe877beb7411d976db4b662d165e31ee5bd17f9a306f3bc4cebab7f"
+      },
+      "samples": {
+        "filename": "AirBatteryMaterials_samples.csv.gz",
+        "rows": 529,
+        "bytes": 38031,
+        "sha256": "90deb9a81cadc17119f1bdd16d4d1c5a2e70f06b9f9831b2aa5f2d36b0a6bb50"
+      },
+      "curves": {
+        "filename": "AirBatteryMaterials_curves.csv.gz",
+        "rows": 1176,
+        "bytes": 225565,
+        "sha256": "1e9ac0897146b7621bd7195afa723ea73674757739bf42a00d38b65d8839bde8"
+      }
+    },
+    "BatteryMaterials": {
+      "papers": {
+        "filename": "BatteryMaterials_papers.csv.gz",
+        "rows": 1690,
+        "bytes": 440721,
+        "sha256": "f3083594d64ff8b512f0f0704f397f11de6b773c5e8693f01fa6d880d5527767"
+      },
+      "samples": {
+        "filename": "BatteryMaterials_samples.csv.gz",
+        "rows": 14087,
+        "bytes": 1032268,
+        "sha256": "eecd2340cb9303ddf7f76581a6563d88327cfcb8226d6cca173e29b8bfbea1d1"
+      },
+      "curves": {
+        "filename": "BatteryMaterials_curves.csv.gz",
+        "rows": 32586,
+        "bytes": 6703231,
+        "sha256": "af5570eb1ec7b4a326277e410aeb40de0e6d26b42290dddf6bfcc11cd6234b66"
+      }
+    },
+    "CondensedMatter": {
+      "papers": {
+        "filename": "CondensedMatter_papers.csv.gz",
+        "rows": 810,
+        "bytes": 155177,
+        "sha256": "526e7fa55886ac17438af5fac17291fc5a18df81cb72e726af018166dd663450"
+      },
+      "samples": {
+        "filename": "CondensedMatter_samples.csv.gz",
+        "rows": 4409,
+        "bytes": 118315,
+        "sha256": "920deaa8a19cefacd9f6aa0c7f15baa64d3fc839e5687fa8e4dc58a47e03d11e"
+      },
+      "curves": {
+        "filename": "CondensedMatter_curves.csv.gz",
+        "rows": 6848,
+        "bytes": 1339995,
+        "sha256": "4e7d3f6a6f6fbbeb865362ff293af72fc93c21832e3e60c48c78036b6b20fb67"
+      }
+    },
+    "DielectricMaterials": {
+      "papers": {
+        "filename": "DielectricMaterials_papers.csv.gz",
+        "rows": 2208,
+        "bytes": 319187,
+        "sha256": "764820363de3710453b692d79b057ddf0a91d45b05375ca43ceec584effaa0bd"
+      },
+      "samples": {
+        "filename": "DielectricMaterials_samples.csv.gz",
+        "rows": 9904,
+        "bytes": 294700,
+        "sha256": "db0b8d360c6d4d721d95265a0740019ffb38b644746bc4b0705e33e73001f409"
+      },
+      "curves": {
+        "filename": "DielectricMaterials_curves.csv.gz",
+        "rows": 16555,
+        "bytes": 3463254,
+        "sha256": "f23cd1858fb6b4edc7fdf30a3a1568b773a1c410e0ac840b8767b4348e9ef884"
+      }
+    },
+    "GeneralDB": {
+      "papers": {
+        "filename": "GeneralDB_papers.csv.gz",
+        "rows": 295,
+        "bytes": 59728,
+        "sha256": "16757ad658303029fef47e5b43d5645fa6d33aba460b86664b937d518189e87c"
+      },
+      "samples": {
+        "filename": "GeneralDB_samples.csv.gz",
+        "rows": 2139,
+        "bytes": 74560,
+        "sha256": "7811ca59d4049372895c0838ff385231dea47aba799f099f9f276d93dec196dc"
+      },
+      "curves": {
+        "filename": "GeneralDB_curves.csv.gz",
+        "rows": 7516,
+        "bytes": 1040157,
+        "sha256": "ab255dd5efb279ad75129e179be7aa44004d85d3da5f5f5e221d74ec3121dd6b"
+      }
+    },
+    "HighThermalConductivityMaterials": {
+      "papers": {
+        "filename": "HighThermalConductivityMaterials_papers.csv.gz",
+        "rows": 349,
+        "bytes": 58708,
+        "sha256": "c0b2e2f43662adedbdc74b4a6167436e5a73c7207637ccc18e5c224fe92295f0"
+      },
+      "samples": {
+        "filename": "HighThermalConductivityMaterials_samples.csv.gz",
+        "rows": 1730,
+        "bytes": 49839,
+        "sha256": "c9f1de93d431c054772a19ce9c214af804af948b896da7d243c85b6e33cb369c"
+      },
+      "curves": {
+        "filename": "HighThermalConductivityMaterials_curves.csv.gz",
+        "rows": 2631,
+        "bytes": 453948,
+        "sha256": "21c734c787709bcd43abd4572de541e71355f5d52725f4c825b1b6c8be61e34b"
+      }
+    },
+    "Hypermaterial": {
+      "papers": {
+        "filename": "Hypermaterial_papers.csv.gz",
+        "rows": 272,
+        "bytes": 38839,
+        "sha256": "c29b227ed936af75d5e2b53ba3c0a2b15ca8ce5d01db27f57a5b828a23db5406"
+      },
+      "samples": {
+        "filename": "Hypermaterial_samples.csv.gz",
+        "rows": 1525,
+        "bytes": 62545,
+        "sha256": "cc17f5ebf94aa9ca734108accdb436f1f6d2d1e1216c06263bd63f12d4605411"
+      },
+      "curves": {
+        "filename": "Hypermaterial_curves.csv.gz",
+        "rows": 2509,
+        "bytes": 720063,
+        "sha256": "02036d0ca3f2a415fe671acd3534d92e151d6b049d193a2603df30ceb516054e"
+      }
+    },
+    "LowThermalConductivityMaterials": {
+      "papers": {
+        "filename": "LowThermalConductivityMaterials_papers.csv.gz",
+        "rows": 274,
+        "bytes": 52321,
+        "sha256": "c2ddf9f1ad143f72f11161d9991b26ea77496c7eeca60fc900d7fed4ad21b60c"
+      },
+      "samples": {
+        "filename": "LowThermalConductivityMaterials_samples.csv.gz",
+        "rows": 1649,
+        "bytes": 62413,
+        "sha256": "8d558514a8b42bdfdaaa4989b5447eb43328cfc915740e4ef433a87ea2eed38c"
+      },
+      "curves": {
+        "filename": "LowThermalConductivityMaterials_curves.csv.gz",
+        "rows": 3518,
+        "bytes": 564361,
+        "sha256": "9ffdfa42208e8bcd8a2b42cbea925120c39a7c47bab6fcfccf0cd81698bfc8e7"
+      }
+    },
+    "MagneticMaterials": {
+      "papers": {
+        "filename": "MagneticMaterials_papers.csv.gz",
+        "rows": 2234,
+        "bytes": 415904,
+        "sha256": "4fc83e155c7c23b6b248d070a22f8243ead61881075ec59a6b16e158c61aca20"
+      },
+      "samples": {
+        "filename": "MagneticMaterials_samples.csv.gz",
+        "rows": 16505,
+        "bytes": 907027,
+        "sha256": "7e878246df22762a721520bafa521d903c84c86d02fbc634d02213f3bde32363"
+      },
+      "curves": {
+        "filename": "MagneticMaterials_curves.csv.gz",
+        "rows": 16869,
+        "bytes": 5112804,
+        "sha256": "5cd23ea21a0df0cbbe832ab9969feb61ed6a820cd01be6f22b35c4b8da02312b"
+      }
+    },
+    "PiezoelectricMaterials": {
+      "papers": {
+        "filename": "PiezoelectricMaterials_papers.csv.gz",
+        "rows": 102,
+        "bytes": 18487,
+        "sha256": "8f059fe5e9008fade0bc93ee876ecb82fed6884987f571e0fb8d4871bfb19e76"
+      },
+      "samples": {
+        "filename": "PiezoelectricMaterials_samples.csv.gz",
+        "rows": 680,
+        "bytes": 17118,
+        "sha256": "89258dd7b354f83a4e51589bd1e3e2366199947455e042a0ee14501919f0b7e8"
+      },
+      "curves": {
+        "filename": "PiezoelectricMaterials_curves.csv.gz",
+        "rows": 1036,
+        "bytes": 454421,
+        "sha256": "5dd8850cb2ad51e762e08045c2ceb7f11465cd4c3826a5f2980f1951644c1dc3"
+      }
+    },
+    "Resistor": {
+      "papers": {
+        "filename": "Resistor_papers.csv.gz",
+        "rows": 786,
+        "bytes": 146561,
+        "sha256": "c25f20b3db724d0e7ca37ca68c7adb4d0b3ccd75c813a6db02ac73677defe736"
+      },
+      "samples": {
+        "filename": "Resistor_samples.csv.gz",
+        "rows": 3776,
+        "bytes": 92388,
+        "sha256": "9ae8a1afffab986e17b9330b47e5e517c57ffe5ec0e72909e0e1dbded31533b9"
+      },
+      "curves": {
+        "filename": "Resistor_curves.csv.gz",
+        "rows": 4597,
+        "bytes": 687922,
+        "sha256": "66065d7484aec0d43b205492d952a4159d7a7711d8299af06cdf864c5d96ca0d"
+      }
+    },
+    "SolidStateBatteryMaterials": {
+      "papers": {
+        "filename": "SolidStateBatteryMaterials_papers.csv.gz",
+        "rows": 109,
+        "bytes": 27247,
+        "sha256": "83fe8fc24b111f1bc7855bc05bdf3a26eecbc410220dfccd7f04f7deb8b1afaa"
+      },
+      "samples": {
+        "filename": "SolidStateBatteryMaterials_samples.csv.gz",
+        "rows": 967,
+        "bytes": 21044,
+        "sha256": "81cddb5cdcb7530f73d0945d49da4b27ad511fcb9c105e9d703bd73fc7ace495"
+      },
+      "curves": {
+        "filename": "SolidStateBatteryMaterials_curves.csv.gz",
+        "rows": 2002,
+        "bytes": 395217,
+        "sha256": "ca2fd04e77f81120e9149e3a80bb3a545c647fe111766d158bd38494048c4f39"
+      }
+    },
+    "ThermoelectricMaterials": {
+      "papers": {
+        "filename": "ThermoelectricMaterials_papers.csv.gz",
+        "rows": 9485,
+        "bytes": 1457310,
+        "sha256": "cf2a12aaed57484e475af3b51fa184dc7b515dd1b6abb121f508743886e88734"
+      },
+      "samples": {
+        "filename": "ThermoelectricMaterials_samples.csv.gz",
+        "rows": 55213,
+        "bytes": 2052912,
+        "sha256": "5a7e50db07b07a47b31308179dacca0a63d8ff2400253cd2bf13070caa41c30a"
+      },
+      "curves": {
+        "filename": "ThermoelectricMaterials_curves.csv.gz",
+        "rows": 155829,
+        "bytes": 25170312,
+        "sha256": "128e88ed6b08a086caf097f36c64d84b07fa72f776388b3139c23e2b82a4ed5b"
+      }
+    }
+  }
+}

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,2 @@
+pandas>=2.0
+gdown>=5.0

--- a/scripts/split.py
+++ b/scripts/split.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Split Starrydata all-data CSVs into per-project CSV.gz files.
+
+Per-project membership is defined by the curves table:
+  - curves: rows whose `project_names` JSON array contains the project name
+  - papers: rows whose `SID` appears in the project's curves
+  - samples: rows whose composite (SID, sample_id) appears in the project's curves
+    (sample_id is paper-local, NOT globally unique, so SID is required)
+
+Matches the counts shown on https://starrydata.github.io/links/.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import sys
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+
+PAPER_CSV = "starrydata_papers.csv"
+SAMPLE_CSV = "starrydata_samples.csv"
+CURVE_CSV = "starrydata_curves.csv"
+SNAPSHOT_TXT = "db_snapshot.txt"
+
+
+def extract_zip(zip_path: Path, extract_dir: Path) -> None:
+    with zipfile.ZipFile(zip_path) as zf:
+        zf.extractall(extract_dir)
+
+
+def project_names_of(value: object) -> list[str]:
+    if not isinstance(value, str) or not value:
+        return []
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [x for x in dict.fromkeys(parsed) if isinstance(x, str)]
+
+
+def gzip_write(df: pd.DataFrame, dest: Path) -> int:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(dest, index=False, compression="gzip")
+    return dest.stat().st_size
+
+
+def sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def split(zip_path: Path, out_dir: Path) -> dict:
+    work = out_dir / "_extracted"
+    if work.exists():
+        shutil.rmtree(work)
+    work.mkdir(parents=True)
+    extract_zip(zip_path, work)
+
+    snapshot = (work / SNAPSHOT_TXT).read_text().strip() if (work / SNAPSHOT_TXT).exists() else ""
+
+    print(f"[load] {PAPER_CSV}", file=sys.stderr)
+    papers = pd.read_csv(work / PAPER_CSV, dtype=str, keep_default_na=False)
+    print(f"[load] {SAMPLE_CSV}", file=sys.stderr)
+    samples = pd.read_csv(work / SAMPLE_CSV, dtype=str, keep_default_na=False)
+    print(f"[load] {CURVE_CSV}", file=sys.stderr)
+    curves = pd.read_csv(work / CURVE_CSV, dtype=str, keep_default_na=False)
+
+    curve_projects = curves["project_names"].map(project_names_of)
+    all_projects: set[str] = set()
+    for projs in curve_projects:
+        all_projects.update(projs)
+    projects_sorted = sorted(all_projects)
+    print(f"[info] {len(projects_sorted)} projects detected from curves", file=sys.stderr)
+
+    out_data = out_dir / "data"
+    if out_data.exists():
+        shutil.rmtree(out_data)
+    out_data.mkdir(parents=True)
+
+    sample_key = samples["SID"] + "\x00" + samples["sample_id"]
+
+    all_data: dict[str, dict] = {}
+    for kind, df in (("papers", papers), ("samples", samples), ("curves", curves)):
+        fname = f"all_{kind}.csv.gz"
+        fpath = out_data / fname
+        size = gzip_write(df, fpath)
+        all_data[kind] = {
+            "filename": fname,
+            "rows": int(len(df)),
+            "bytes": size,
+            "sha256": sha256(fpath),
+        }
+    print(
+        f"[done] {'all (whole dataset)':40} papers={len(papers):6} samples={len(samples):6} curves={len(curves):7}",
+        file=sys.stderr,
+    )
+
+    manifest: dict[str, dict] = {}
+    for project in projects_sorted:
+        mask = curve_projects.map(lambda ps, p=project: p in ps)
+        c_sub = curves[mask]
+        sid_set = set(c_sub["SID"].unique())
+        curve_sample_keys = set((c_sub["SID"] + "\x00" + c_sub["sample_id"]).unique())
+        p_sub = papers[papers["SID"].isin(sid_set)]
+        s_sub = samples[sample_key.isin(curve_sample_keys)]
+
+        files: dict[str, dict] = {}
+        for kind, df in (("papers", p_sub), ("samples", s_sub), ("curves", c_sub)):
+            fname = f"{project}_{kind}.csv.gz"
+            fpath = out_data / fname
+            size = gzip_write(df, fpath)
+            files[kind] = {
+                "filename": fname,
+                "rows": int(len(df)),
+                "bytes": size,
+                "sha256": sha256(fpath),
+            }
+        print(
+            f"[done] {project:40} papers={len(p_sub):6} samples={len(s_sub):6} curves={len(c_sub):7}",
+            file=sys.stderr,
+        )
+        manifest[project] = files
+
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "db_snapshot": snapshot,
+        "source_zip": zip_path.name,
+        "all_data": all_data,
+        "projects": manifest,
+    }
+    (out_dir / "manifest.json").write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+    print(f"[write] {out_dir / 'manifest.json'}", file=sys.stderr)
+
+    shutil.rmtree(work)
+    return payload
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--zip", required=True, type=Path)
+    ap.add_argument("--out", required=True, type=Path)
+    args = ap.parse_args()
+    split(args.zip, args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Mirrors the working proof-of-concept at <https://atsumitanaka.github.io/starrydata-datasets/> into this canonical repo. After this lands the page will be live at:

**https://starrydata.github.io/starrydata_datasets/**

## What's added

| Path | Purpose |
|---|---|
| \`docs/index.html\` | SPA — reads \`counts.json\` from starrydata.github.io, shows the project table with \`[papers][samples][curves]\` download buttons sourced from this repo's Releases |
| \`docs/manifest.json\` | Latest split metadata (filename / rows / bytes / sha256) per file |
| \`scripts/split.py\` | Splits the daily Drive zip into 13 projects × 3 files + 3 \`all_*\` files |
| \`scripts/requirements.txt\` | pandas, gdown |
| \`.github/workflows/daily-split.yml\` | Daily 03:00 JST cron — fetch, split, publish to Releases (\`data-YYYYMMDD\` + \`latest\`), commit manifest |
| \`.gitignore\` | excludes \`.venv/\`, \`_out/\`, \`*.zip\` |

The existing \`datasets/\`, \`doilist/\`, \`RockSalt_type/\` directories are left untouched.

## Why \`/docs\`

Pages is already configured to serve from \`master\` branch / \`/docs\` path on this repo (legacy build_type). Putting the SPA at \`docs/index.html\` matches that without requiring any Pages config change.

## Pipeline diagram

\`\`\`
Google Drive (zip, updated 02:00 JST every day)
        │  gdown
        ▼
GitHub Actions (03:00 JST cron)
        │  scripts/split.py
        ▼
13 × 3 + 3 = 42 CSV.gz files + manifest.json (~52 MB total)
        │  gh release create
        ▼
GitHub Releases  (tag: data-YYYYMMDD + latest)
        │  fetch
        ▼
docs/index.html  (https://starrydata.github.io/starrydata_datasets/)
\`\`\`

## Admin-only follow-ups after merge

Two steps that require admin (the PR author has \`write\` but not \`admin\`):

1. **Settings → Actions → General → Workflow permissions** → **"Read and write permissions"**
   The workflow needs to publish releases and push a commit updating \`docs/manifest.json\`.

2. **Actions tab → "Daily split & release" → Run workflow**
   Kick off the first run so Releases get populated before the SPA goes live.

## Test plan

- [ ] PR merges cleanly into master
- [ ] After (1) and (2) above: workflow run succeeds (\`gh run watch\`)
- [ ] \`gh release view latest\` shows 40+ assets (39 per-project + 3 all_* + manifest)
- [ ] https://starrydata.github.io/starrydata_datasets/ renders the project table
- [ ] Clicking a button downloads the correct \`.csv.gz\`
- [ ] Pre-existing directories (\`datasets/\`, \`doilist/\`, \`RockSalt_type/\`) are unchanged