### PR TITLE
feat(ci): auto-create GitHub issue on workflow failure

### DIFF
--- a/.github/workflows/daily-split.yml
+++ b/.github/workflows/daily-split.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 concurrency:
   group: daily-split
@@ -84,3 +85,37 @@ jobs:
           git add docs/manifest.json
           git commit -m "chore: update manifest.json ($(date -u +%Y-%m-%d))"
           git push
+
+      - name: Open or update issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE="Daily split pipeline failed"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          DRIVE_URL="https://drive.google.com/drive/folders/1OVMP7j61CJFwLtJ-qZFef9ko40Othayh"
+          EXISTING=$(gh issue list --state open --json number,title --jq '.[] | select(.title=="'"$TITLE"'") | .number' | head -1)
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "Another failure on $(date -u +%Y-%m-%d): $RUN_URL"
+          else
+            gh issue create --title "$TITLE" --body "The \`Daily split & release\` workflow failed and the per-project files at \`/releases/latest/\` are now stale.
+
+          - First failed run: $RUN_URL
+          - Date (UTC): $(date -u +%Y-%m-%dT%H:%M:%SZ)
+          - Trigger: ${{ github.event_name }}
+
+          The latest dataset is still available from the [official Google Drive]($DRIVE_URL) while this is being investigated.
+
+          This issue will auto-close on the next successful run."
+          fi
+
+      - name: Close failure issues on success
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE="Daily split pipeline failed"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          for n in $(gh issue list --state open --json number,title --jq '.[] | select(.title=="'"$TITLE"'") | .number'); do
+            gh issue close "$n" --comment "Pipeline succeeded again: $RUN_URL"
+          done


### PR DESCRIPTION
## B. Failure notification — second of three resilience PRs

### What this guards against

PR #3 added a staleness banner so users know when the data is old. But a maintainer still needs to be alerted so they can fix the pipeline. Today a failure goes unnoticed unless someone happens to check the Actions tab.

### What this PR does

Adds two final steps to the workflow:

**On failure** (\`if: failure()\`):
- Look for an existing open issue titled "Daily split pipeline failed"
- If one exists → comment on it ("Another failure on \`<date>\`: \`<run URL>\`")
- If none → create a new issue with the run URL, trigger info, and a Drive fallback link

**On success** (\`if: success()\`):
- Look for any open "Daily split pipeline failed" issues
- Close them with a comment linking to the green run

The issue tracker therefore reflects the actual current state of the pipeline: open when broken, closed when working. No spam from consecutive failures, no manual cleanup needed.

### Permissions

Adds \`issues: write\` to the workflow's \`permissions\` block (in addition to the existing \`contents: write\`).

### Test plan

- [ ] Merge and wait for the next scheduled run — succeeds, nothing happens (no existing issue to close, all good)
- [ ] To verify the failure path without breaking the pipeline, you can temporarily push a commit that makes \`scripts/split.py\` raise on import, run the workflow, confirm an issue is created, revert, run again, confirm the issue auto-closes
- [ ] Consecutive failures comment on the existing issue rather than creating new ones