### PR TITLE
feat(docs): add Drive fallback button to the all-data row

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -33,6 +33,11 @@
   tr.all-data-row td { background: rgba(96, 165, 250, 0.08); }
   tr.all-data-row:hover td { background: rgba(96, 165, 250, 0.14); }
   tr.all-data-row td.pname { color: var(--accent); }
+  tr.all-data-row .dl-grid { grid-template-columns: repeat(4, 1fr); min-width: 360px; }
+  .dl-drive { background: rgba(245, 158, 11, 0.12); border-color: rgba(245, 158, 11, 0.4); color: #fbbf24; }
+  .dl-drive:hover { background: rgba(245, 158, 11, 0.22); border-color: #fbbf24; color: #fde68a; }
+  .dl-drive .sz { color: rgba(251, 191, 36, 0.7); }
+  .dl-drive:hover .sz { color: #fde68a; }
   .totals .stat { background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 14px; text-align: center; }
   .totals .stat .n { font-size: 22px; font-weight: 700; color: var(--accent); }
   .totals .stat .l { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 1px; margin-top: 4px; }
@@ -261,6 +266,7 @@
   }
 
   function allDataRow(counts, manifest) {
+    const driveBtn = `<a class="dl dl-drive" href="${DRIVE_URL}" target="_blank" rel="noopener" title="Always-current full zip mirrored from the official Starrydata Google Drive">Drive zip<span class="sz">always fresh</span></a>`;
     return `
       <tr class="all-data-row">
         <td class="pname">All projects (whole dataset)</td>
@@ -268,7 +274,7 @@
         <td>${fmtNum(counts.figures ?? 0)}</td>
         <td>${fmtNum(counts.samples ?? 0)}</td>
         <td>${fmtNum(counts.curves ?? 0)}</td>
-        <td class="dl-cell"><div class="dl-grid">${allDlButton("papers", manifest)}${allDlButton("samples", manifest)}${allDlButton("curves", manifest)}</div></td>
+        <td class="dl-cell"><div class="dl-grid">${allDlButton("papers", manifest)}${allDlButton("samples", manifest)}${allDlButton("curves", manifest)}${driveBtn}</div></td>
       </tr>
     `;
   }


### PR DESCRIPTION
## C. Drive fallback button — third of three resilience PRs

### What completes the resilience story

| | Symptom when pipeline fails | What guards it |
|---|---|---|
| User sees old data without knowing | Silent staleness | **#3 — Staleness banner** (merged) |
| Nobody fixes it because nobody knows | Pipeline stays broken | **#4 — Auto-issue on failure** (merged) |
| User can't get fresh data at all | Page broken in practice | **This PR — Drive fallback button** |

### What this PR does

Adds a 4th button to the "All projects (whole dataset)" row of the table:

\`\`\`
All projects (whole dataset)  ...  [all_papers] [all_samples] [all_curves] [Drive zip]
                                   ↑ from our Releases (can go stale)     ↑ always fresh
\`\`\`

- The new button is amber-tinted so it visually reads as the safety fallback, distinct from the blue release buttons
- Links straight to the official Drive folder, which the upstream team updates twice daily — no dependency on our workflow being green
- The all-data row's button grid widens from 3 to 4 columns just for that row; project rows still show 3

### Test plan

- [ ] All-data row shows four buttons; project rows still show three
- [ ] Drive button visually distinct (amber vs blue)
- [ ] Click opens the Drive folder in a new tab
- [ ] Even if the staleness banner appears (manifest old), the Drive button still works — that's the whole point

### After this lands

The Datasets page can serve the canonical "Datasets" menu entry on the Starrydata2 web system with confidence: users always have a working path to the current data, maintainers get alerted when the pipeline breaks, and users self-route to Drive in the meantime.