### PR TITLE
style(docs): make Star button bigger and clearly GitHub-branded

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -29,7 +29,13 @@
   header a:hover { color: var(--accent-hi); }
   .meta-row { display: flex; gap: 24px; justify-content: center; align-items: center; margin-top: 18px; flex-wrap: wrap; font-size: 13px; color: var(--muted); }
   .meta-row b { color: var(--text); font-weight: 600; }
-  .meta-row .gh-star { display: inline-flex; align-items: center; min-height: 28px; }
+  .gh-star-wrap { display: flex; justify-content: center; margin-top: 24px; }
+  .gh-star-card { display: inline-flex; align-items: center; gap: 16px; padding: 14px 24px; background: #161b22; border: 1px solid rgba(240, 246, 252, 0.12); border-radius: 10px; color: #f0f6fc; transition: all 0.2s ease; }
+  .gh-star-card:hover { border-color: rgba(240, 246, 252, 0.28); box-shadow: 0 6px 22px rgba(0, 0, 0, 0.35); transform: translateY(-1px); }
+  .gh-star-card .gh-logo { width: 30px; height: 30px; fill: currentColor; flex-shrink: 0; }
+  .gh-star-card .gh-label { font-size: 15px; font-weight: 600; letter-spacing: 0.2px; }
+  .gh-star-card .gh-label small { display: block; font-size: 11px; font-weight: 400; color: #8b949e; margin-top: 2px; }
+  .gh-star-card .github-button-wrap { display: inline-flex; align-items: center; transform: scale(1.15); transform-origin: left center; padding-left: 4px; }
   .totals { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 28px; }
   tr.all-data-row td { background: rgba(96, 165, 250, 0.08); }
   tr.all-data-row:hover td { background: rgba(96, 165, 250, 0.14); }
@@ -89,14 +95,22 @@
     <div class="meta-row">
       <span>DB snapshot: <b id="snapshot">—</b></span>
       <span>Files generated: <b id="generated">—</b></span>
-      <span class="gh-star">
-        <a class="github-button"
-           href="https://github.com/starrydata/starrydata_datasets"
-           data-icon="octicon-star"
-           data-size="large"
-           data-show-count="true"
-           aria-label="Star starrydata/starrydata_datasets on GitHub">Star</a>
-      </span>
+    </div>
+    <div class="gh-star-wrap">
+      <div class="gh-star-card">
+        <svg class="gh-logo" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.4 3-.405 1.02.005 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
+        </svg>
+        <div class="gh-label">Star this dataset on GitHub<small>starrydata/starrydata_datasets</small></div>
+        <span class="github-button-wrap">
+          <a class="github-button"
+             href="https://github.com/starrydata/starrydata_datasets"
+             data-icon="octicon-star"
+             data-size="large"
+             data-show-count="true"
+             aria-label="Star starrydata/starrydata_datasets on GitHub">Star</a>
+        </span>
+      </div>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary

The previous Star widget sat inline in the meta-row alongside "DB snapshot" / "Files generated", so it was small and didn't read as "GitHub" at a glance.

This PR promotes it into a bigger, clearly branded card:

\`\`\`
[Octocat logo]  Star this dataset on GitHub      [⭐ Star  N]
                starrydata/starrydata_datasets
\`\`\`

- GitHub Dark theme colors (\`#161b22\` bg, off-white text) so the card itself reads as a GitHub element
- The actual Octocat mark on the left
- A clear label "Star this dataset on GitHub" + repo slug subtitle
- The official buttons.github.io widget (still functional in-page) inside, scaled 1.15× for visual weight
- Centered just below the header meta-row so it's the first thing visitors see after the title

## Test plan

- [ ] Card renders centered below the meta-row
- [ ] Octocat logo + text + Star widget all visible on one line on desktop
- [ ] On narrow viewports the elements stack reasonably (the card itself doesn't break)
- [ ] Clicking the Star opens GitHub auth popup (logged out) or stars immediately (logged in)
- [ ] Hover lifts the card with a soft shadow