### PR TITLE
docs: add 2026/06/26 changelog entry (per-project downloads + gzip)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 
 ## Changelog
 
+### 2026/06/26
+- Added per-project dataset downloads at https://starrydata.github.io/starrydata_datasets/. Each project (ThermoelectricMaterials, BatteryMaterials, MagneticMaterials, etc.) can now be downloaded separately as `papers` / `samples` / `curves` files, alongside the full unsplit dataset.
+- Compressed all downloads as gzipped CSV (`.csv.gz`) to reduce file size. Load directly with `pandas.read_csv(url, compression="gzip")` or decompress before opening in Excel.
+
 ### 2025/08/22
 - Add figure_name field to curve dataset.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -156,6 +156,13 @@
     <details class="changelog-box" open>
       <summary>Changelog</summary>
       <div class="changelog-entry">
+        <h3>2026/06/26</h3>
+        <ul>
+          <li>Added per-project dataset downloads at <a href="https://starrydata.github.io/starrydata_datasets/" target="_blank" rel="noopener">starrydata.github.io/starrydata_datasets</a>. Each project (<code>ThermoelectricMaterials</code>, <code>BatteryMaterials</code>, <code>MagneticMaterials</code>, etc.) can now be downloaded separately as <code>papers</code> / <code>samples</code> / <code>curves</code> files, alongside the full unsplit dataset.</li>
+          <li>Compressed all downloads as gzipped CSV (<code>.csv.gz</code>) to reduce file size. Load directly with <code>pandas.read_csv(url, compression="gzip")</code> or decompress before opening in Excel.</li>
+        </ul>
+      </div>
+      <div class="changelog-entry">
         <h3>2025/08/22</h3>
         <ul><li>Add <code>figure_name</code> field to curve dataset.</li></ul>
       </div>


### PR DESCRIPTION
## Summary

Adds the 2026/06/26 changelog entry to both:
- \`README.md\`
- \`docs/index.html\` (the SPA's Changelog section)

### Entry text

> ### 2026/06/26
> - Added per-project dataset downloads at https://starrydata.github.io/starrydata_datasets/. Each project (ThermoelectricMaterials, BatteryMaterials, MagneticMaterials, etc.) can now be downloaded separately as \`papers\` / \`samples\` / \`curves\` files, alongside the full unsplit dataset.
> - Compressed all downloads as gzipped CSV (\`.csv.gz\`) to reduce file size. Load directly with \`pandas.read_csv(url, compression="gzip")\` or decompress before opening in Excel.

Documents the two user-facing changes shipped in PRs #2 / #3 / #5: per-project files and gzipped CSV.

## Test plan

- [ ] README renders the new entry at the top of the Changelog
- [ ] SPA's Changelog section shows the new entry above 2025/08/22