### PR TITLE
style(docs): bigger download-button text + cleaner KB/MB rollover

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -73,9 +73,9 @@
   .changelog-entry ul a { color: var(--accent); text-decoration: none; }
   .changelog-entry ul a:hover { text-decoration: underline; }
   .changelog-entry code { background: rgba(96, 165, 250, 0.12); padding: 1px 6px; border-radius: 3px; font-size: 12px; }
-  .dl { display: flex; align-items: center; justify-content: center; gap: 4px; padding: 6px 10px; background: rgba(96, 165, 250, 0.12); border: 1px solid rgba(96, 165, 250, 0.3); border-radius: 4px; color: var(--accent); text-decoration: none; font-size: 11px; font-weight: 600; transition: all 0.15s ease; white-space: nowrap; }
+  .dl { display: flex; align-items: center; justify-content: center; gap: 5px; padding: 7px 12px; background: rgba(96, 165, 250, 0.12); border: 1px solid rgba(96, 165, 250, 0.3); border-radius: 4px; color: var(--accent); text-decoration: none; font-size: 13px; font-weight: 600; transition: all 0.15s ease; white-space: nowrap; }
   .dl:hover { background: rgba(96, 165, 250, 0.25); border-color: var(--accent); color: var(--accent-hi); }
-  .dl .sz { font-weight: 400; color: var(--muted); font-size: 10px; }
+  .dl .sz { font-weight: 400; color: var(--muted); font-size: 11px; }
   .dl:hover .sz { color: var(--accent-hi); }
   .dl-cell { min-width: 280px; }
   .dl-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; }
@@ -237,8 +237,10 @@
   const fmtBytes = (b) => {
     if (b == null) return "";
     if (b < 1024) return `${b} B`;
-    if (b < 1024 * 1024) return `${(b / 1024).toFixed(0)} KB`;
-    return `${(b / 1024 / 1024).toFixed(1)} MB`;
+    const kb = b / 1024;
+    // Roll over to MB once KB would be 4 digits, so 1014 KB → "1.0 MB".
+    if (kb < 1000) return `${kb.toFixed(0)} KB`;
+    return `${(kb / 1024).toFixed(1)} MB`;
   };
   const TZ_LIST = [
     { tz: "UTC", label: "UTC" },


### PR DESCRIPTION
## Summary

Two related tweaks to the download buttons:

### Bigger text inside the buttons

The 11px label / 10px size text was too small to comfortably read on the buttons in the project table. Bumped to **13px label / 11px size**, with a touch more padding.

### Cleaner KB/MB rollover

Files like \`1014 KB\` were displayed verbatim — should have rolled over to \`1.0 MB\`. The threshold was the strict 1 MiB boundary (\`b < 1024 * 1024\`), so anything 1000–1023 KB stayed in KB.

Changed to roll over once the KB value would be four digits:

\`\`\`js
const kb = b / 1024;
if (kb < 1000) return \`\${kb.toFixed(0)} KB\`;
return \`\${(kb / 1024).toFixed(1)} MB\`;
\`\`\`

\`1014 KB\` now renders as \`1.0 MB\`, matching what its neighbours show.

## Test plan

- [ ] Buttons are easier to read on the project table
- [ ] All-data row's \`all_papers\`, which sat around 1.4 MB, still reads as MB
- [ ] Any per-project file in the 1000–1023 KB range now shows MB rather than 1014 KB