### PR TITLE
Drive Pages listing from manifest.json (drop counts.json dep)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -227,7 +227,6 @@
   const REPO_OWNER = "starrydata";
   const REPO_NAME = "starrydata_datasets";
 
-  const COUNTS_URL = "https://starrydata.github.io/json/counts.json";
   const MANIFEST_URL = "./manifest.json";
   const RELEASE_BASE = `https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/latest/download`;
   const REPO_URL = `https://github.com/${REPO_OWNER}/${REPO_NAME}`;
@@ -296,23 +295,27 @@
     banner.style.display = "block";
   }
 
-  function allDataRow(counts, manifest) {
+  const projectCounts = (entry) => entry?.counts ?? {};
+
+  function allDataRow(manifest) {
+    const totals = manifest?.totals ?? {};
     const driveBtn = `<a class="dl dl-drive" href="${DRIVE_URL}" target="_blank" rel="noopener" title="Always-current full zip mirrored from the official Starrydata Google Drive">Drive zip<span class="sz">always fresh</span></a>`;
     return `
       <tr class="all-data-row">
         <td class="pname">All projects (whole dataset)</td>
-        <td>${fmtNum(counts.papers ?? 0)}</td>
-        <td>${fmtNum(counts.figures ?? 0)}</td>
-        <td>${fmtNum(counts.samples ?? 0)}</td>
-        <td>${fmtNum(counts.curves ?? 0)}</td>
+        <td>${fmtNum(totals.papers ?? 0)}</td>
+        <td>${fmtNum(totals.figures ?? 0)}</td>
+        <td>${fmtNum(totals.samples ?? 0)}</td>
+        <td>${fmtNum(totals.curves ?? 0)}</td>
         <td class="dl-cell"><div class="dl-grid">${allDlButton("papers", manifest)}${allDlButton("samples", manifest)}${allDlButton("curves", manifest)}${driveBtn}</div></td>
       </tr>
     `;
   }
 
-  function renderTotals(counts) {
+  function renderTotals(manifest) {
+    const totals = manifest?.totals ?? {};
     const html = ["papers", "figures", "samples", "curves"].map((k) =>
-      `<div class="stat"><div class="n">${fmtNum(counts[k] ?? 0)}</div><div class="l">${k}</div></div>`
+      `<div class="stat"><div class="n">${fmtNum(totals[k] ?? 0)}</div><div class="l">${k}</div></div>`
     ).join("");
     document.getElementById("totals").innerHTML = html;
   }
@@ -325,11 +328,12 @@
     return `<a class="dl" href="${url}" title="${meta.rows.toLocaleString()} rows, sha256:${meta.sha256.slice(0,12)}…">${kind}<span class="sz">${fmtBytes(meta.bytes)}</span></a>`;
   }
 
-  function renderTable(counts, manifest) {
+  function renderTable(manifest) {
     // Sort by curves desc, but keep Battery-family projects adjacent
     // (anchored to the largest battery's natural position).
     const isBattery = (n) => /Battery/.test(n);
-    const all = Object.entries(counts.projects ?? {});
+    const all = Object.entries(manifest?.projects ?? {})
+      .map(([name, entry]) => [name, projectCounts(entry), entry]);
     const batteryCurves = all.filter(([n]) => isBattery(n)).map(([, c]) => c.curves ?? 0);
     const batteryAnchor = batteryCurves.length ? Math.max(...batteryCurves) : -Infinity;
     const keyOf = ([name, c]) => isBattery(name) ? batteryAnchor : (c.curves ?? 0);
@@ -356,7 +360,7 @@
             <th>Project</th><th>Papers</th><th>Figures</th><th>Samples</th><th>Curves</th><th>Download</th>
           </tr>
         </thead>
-        <tbody>${allDataRow(counts, manifest)}${rows}</tbody>
+        <tbody>${allDataRow(manifest)}${rows}</tbody>
       </table>
     `;
   }
@@ -369,12 +373,9 @@
 
   (async function () {
     try {
-      const [counts, manifest] = await Promise.all([
-        fetchJSON(COUNTS_URL),
-        fetchJSON(MANIFEST_URL).catch(() => ({ projects: {} })),
-      ]);
-      renderTotals(counts);
-      renderTable(counts, manifest);
+      const manifest = await fetchJSON(MANIFEST_URL);
+      renderTotals(manifest);
+      renderTable(manifest);
       document.getElementById("snapshot").textContent = fmtDate(manifest.db_snapshot);
       document.getElementById("generated").textContent = fmtDate(manifest.generated_at);
       checkStaleness(manifest);

--- a/scripts/split.py
+++ b/scripts/split.py
@@ -83,6 +83,16 @@ def split(zip_path: Path, out_dir: Path) -> dict:
     projects_sorted = sorted(all_projects)
     print(f"[info] {len(projects_sorted)} projects detected from curves", file=sys.stderr)
 
+    def _nunique_nonempty(series: pd.Series) -> int:
+        return int(series[series != ""].nunique())
+
+    totals = {
+        "papers": _nunique_nonempty(curves["SID"]),
+        "figures": _nunique_nonempty(curves["figure_id"]) if "figure_id" in curves.columns else 0,
+        "samples": int(len(samples)),
+        "curves": int(len(curves)),
+    }
+
     out_data = out_dir / "data"
     if out_data.exists():
         shutil.rmtree(out_data)
@@ -126,8 +136,15 @@ def split(zip_path: Path, out_dir: Path) -> dict:
                 "bytes": size,
                 "sha256": sha256(fpath),
             }
+        project_figures = _nunique_nonempty(c_sub["figure_id"]) if "figure_id" in c_sub.columns else 0
+        files["counts"] = {
+            "papers": int(len(p_sub)),
+            "figures": project_figures,
+            "samples": int(len(s_sub)),
+            "curves": int(len(c_sub)),
+        }
         print(
-            f"[done] {project:40} papers={len(p_sub):6} samples={len(s_sub):6} curves={len(c_sub):7}",
+            f"[done] {project:40} papers={len(p_sub):6} figures={project_figures:6} samples={len(s_sub):6} curves={len(c_sub):7}",
             file=sys.stderr,
         )
         manifest[project] = files
@@ -136,6 +153,7 @@ def split(zip_path: Path, out_dir: Path) -> dict:
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "db_snapshot": snapshot,
         "source_zip": zip_path.name,
+        "totals": totals,
         "all_data": all_data,
         "projects": manifest,
     }


### PR DESCRIPTION
## Summary
- Pages table (docs/index.html) was iterating **counts.json** to decide which projects to show. counts.json is regenerated **monthly** in `starrydata/starrydata.github.io` from a Figshare mirror, so new projects added to the DB in-between snapshots — e.g. `OrganicThermoelectricMaterials` — did not appear on the site until the next monthly refresh, even though they were already in the daily manifest/release.
- Make `manifest.json` self-contained (add per-project `counts.figures` and top-level `totals`) and let `index.html` render from it alone. Removes both the Figshare lag and the cross-repo dependency on `starrydata.github.io/json/counts.json`.

## Changes
- `scripts/split.py`
  - New top-level `totals` block in `manifest.json`: `{papers, figures, samples, curves}` computed from the curves CSV (papers = unique non-empty `SID`, figures = unique non-empty `figure_id`, samples = total rows in samples CSV, curves = total rows in curves CSV — matches the definitions previously used by `count_dataset.py`).
  - New per-project `counts` sub-object with the same four keys. `papers`/`samples`/`curves` mirror the existing split file row counts; `figures` is new (unique `figure_id` in that project's curves).
- `docs/index.html`
  - Remove `COUNTS_URL` and the cross-origin fetch.
  - `renderTotals` / `allDataRow` / `renderTable` now take `manifest` alone and read `manifest.totals` and `manifest.projects[name].counts`.

## Compatibility
- `manifest.json` gains new keys; existing keys are unchanged. Any external consumer that reads `all_data` or `projects[name].{papers,samples,curves}` (filename/rows/bytes/sha256) continues to work.
- The `Update dataset counts` workflow in `starrydata/starrydata.github.io` is no longer required for this page. It can stay as-is if `counts.json` is used elsewhere; if not, it can be retired in a follow-up.

## Test plan
- [ ] Trigger `Daily split & release` (workflow_dispatch) and confirm the produced `manifest.json` contains `totals` and per-project `counts.figures`.
- [ ] Load https://starrydata.github.io/starrydata_datasets/ after Pages redeploys and confirm:
  - `OrganicThermoelectricMaterials` row appears in the table.
  - Totals card and "All projects" row numbers still match previous values (allowing for daily churn).
  - Download buttons still resolve to `releases/latest/download/<file>`.
- [ ] DevTools Network tab: only `./manifest.json` is fetched (no `counts.json` request).