### PR TITLE
docs: rewrite README to describe the daily-split pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,177 @@
 # starrydata_datasets
 
-## Dataset Repository
+Daily per-project splits of the [Starrydata2](https://starrydata.nims.go.jp/) dataset, with a browsable download page at **https://starrydata.github.io/starrydata_datasets/**.
 
-| Repository | Description | Update Schedule | Period |
-|------------|--------------|-----------------|--------|
-| [Google Drive](https://drive.google.com/drive/folders/1OVMP7j61CJFwLtJ-qZFef9ko40Othayh) | Latest dataset only | Twice daily at 00:00 and 12:00 | from 2024/06/13 |
-| [Figshare](https://figshare.com/projects/Starrydata_datasets/155129) | Past datasets | Daily until 2024/06/06, then monthly | from 2022/12/22 |
-| [Github](https://github.com/starrydata/starrydata_datasets) | Past datasets | As needed | from 2019/7/11 until 2022/12/22 |
+Historically this repository also hosted the raw CSVs (from 2019/7/11 until 2022/12/22); those older archives are still available via git tags.
 
+## Dataset repositories
+
+| Repository | Description | Update schedule | Period |
+|------------|-------------|-----------------|--------|
+| [Google Drive](https://drive.google.com/drive/folders/1OVMP7j61CJFwLtJ-qZFef9ko40Othayh) | Latest full dataset (single ZIP) | Twice daily at 00:00 and 12:00 JST | from 2024/06/13 |
+| [GitHub Releases (this repo)](https://github.com/starrydata/starrydata_datasets/releases) | Per-project splits + full dataset, as `.csv.gz` | Daily around 03:00 JST | from 2026/06/25 |
+| [Figshare](https://figshare.com/projects/Starrydata_datasets/155129) | Archival snapshots | Daily until 2024/06/06, then monthly | from 2022/12/22 |
+| [GitHub tags (this repo)](https://github.com/starrydata/starrydata_datasets/tags) | Legacy snapshots | As needed | 2019/7/11 – 2022/12/22 |
+
+## What this repository does
+
+Every day the `Daily split & release` workflow:
+
+1. Downloads the latest full ZIP from Google Drive (`starrydata_dataset.zip`).
+2. Runs `scripts/split.py`, which produces per-project files by looking at each row of `starrydata_curves.csv` and reading its `project_names` JSON array.
+3. Publishes two GitHub Releases:
+   - `data-YYYYMMDD` — the dated snapshot.
+   - `latest` — recreated to always mirror the newest snapshot.
+4. Commits `docs/manifest.json` to `master`, which triggers a GitHub Pages redeploy.
+
+### Membership rules (per project)
+
+Membership is defined **from curves outward**, so the counts match [starrydata.github.io/links/](https://starrydata.github.io/links/):
+
+- **curves**: rows whose `project_names` array contains the project.
+- **papers**: rows in `starrydata_papers.csv` whose `SID` appears in the project's curves.
+- **samples**: rows in `starrydata_samples.csv` whose composite key `(SID, sample_id)` appears in the project's curves (`sample_id` alone is paper-local, not globally unique).
+- **figures**: number of distinct non-empty `figure_id` values in the project's curves.
+
+## Downloading
+
+Every file lives under a **stable** URL that always points at the newest snapshot:
+
+```
+https://github.com/starrydata/starrydata_datasets/releases/latest/download/<FILENAME>
+```
+
+### Full dataset
+
+| File | Contents |
+|------|----------|
+| `all_papers.csv.gz` | Every paper |
+| `all_samples.csv.gz` | Every sample |
+| `all_curves.csv.gz` | Every curve |
+
+### Per-project
+
+For each project (e.g. `ThermoelectricMaterials`, `BatteryMaterials`, `MagneticMaterials`, `OrganicThermoelectricMaterials`, …), three files:
+
+- `<Project>_papers.csv.gz`
+- `<Project>_samples.csv.gz`
+- `<Project>_curves.csv.gz`
+
+The canonical list of available projects and files is `manifest.json` (see below).
+
+### Loading in Python
+
+```python
+import pandas as pd
+
+BASE = "https://github.com/starrydata/starrydata_datasets/releases/latest/download"
+curves = pd.read_csv(f"{BASE}/ThermoelectricMaterials_curves.csv.gz", compression="gzip")
+```
+
+### Opening in Excel
+
+`.csv.gz` is gzipped — decompress first (`gunzip <file>` on macOS/Linux, or 7-Zip on Windows) and open the resulting `.csv`.
+
+## manifest.json
+
+`docs/manifest.json` is regenerated on every run and mirrored to https://starrydata.github.io/starrydata_datasets/manifest.json. Its schema:
+
+```jsonc
+{
+  "generated_at": "2026-07-17T08:47:07+00:00",         // when this manifest was built (UTC ISO)
+  "db_snapshot":  "2026-07-17 16:58:34 UTC+0900 (JST)", // upstream Starrydata DB snapshot time
+  "source_zip":   "starrydata_dataset.zip",
+  "totals": {                     // Whole-DB counts (match links page definitions)
+    "papers":  17381,             //   unique non-empty SID in curves ("papers with data")
+    "figures": 60228,             //   unique non-empty figure_id in curves
+    "samples": 105260,            //   total rows in starrydata_samples.csv
+    "curves":  234029             //   total rows in starrydata_curves.csv
+  },
+  "all_data": {
+    "papers":  { "filename": "all_papers.csv.gz",  "rows": 56473,  "bytes": 9460869,  "sha256": "..." },
+    "samples": { "filename": "all_samples.csv.gz", "rows": 105260, "bytes": 4675538,  "sha256": "..." },
+    "curves":  { "filename": "all_curves.csv.gz",  "rows": 234029, "bytes": 43423914, "sha256": "..." }
+  },
+  "projects": {
+    "ThermoelectricMaterials": {
+      "papers":  { "filename": "...", "rows": ..., "bytes": ..., "sha256": "..." },
+      "samples": { "filename": "...", "rows": ..., "bytes": ..., "sha256": "..." },
+      "curves":  { "filename": "...", "rows": ..., "bytes": ..., "sha256": "..." },
+      "counts":  { "papers": ..., "figures": ..., "samples": ..., "curves": ... }
+    }
+  }
+}
+```
+
+The project list is **dynamic** — every project name that appears in any curve's `project_names` array shows up here. No hardcoded allowlist.
+
+Other pages on starrydata.github.io consume this same manifest.
+
+## Manual re-run
+
+Web UI: [Run workflow](https://github.com/starrydata/starrydata_datasets/actions/workflows/daily-split.yml).
+
+CLI:
+
+```sh
+gh workflow run "Daily split & release" -R starrydata/starrydata_datasets
+```
+
+The workflow has `concurrency: daily-split` so a manual run and the scheduled run will serialize, not collide.
+
+## When the pipeline fails
+
+The workflow opens an issue titled `Daily split pipeline failed` on the first failure, comments on it if it fails again, and auto-closes it on the next success. While an incident is open, the always-fresh full ZIP is still available directly from [Google Drive](https://drive.google.com/drive/folders/1OVMP7j61CJFwLtJ-qZFef9ko40Othayh).
+
+## Layout
+
+```
+.github/workflows/daily-split.yml   # daily schedule + workflow_dispatch
+scripts/
+  split.py                          # ZIP → per-project CSV.gz + manifest.json
+  requirements.txt
+docs/
+  index.html                        # Pages UI, renders from manifest.json alone
+  manifest.json                     # latest snapshot metadata (auto-committed)
+```
 
 ## Changelog
 
+### 2026/07/17
+- Rebuilt the Pages listing and Starrydata `links` page to read directly from this repo's daily `manifest.json`. New projects (e.g. `OrganicThermoelectricMaterials`) now appear the day they're added to the DB, instead of waiting for the monthly Figshare mirror. Added `totals` and per-project `counts` (including `figures`) to `manifest.json`.
+
 ### 2026/06/26
-- Added per-project dataset downloads at https://starrydata.github.io/starrydata_datasets/. Each project (ThermoelectricMaterials, BatteryMaterials, MagneticMaterials, etc.) can now be downloaded separately as `papers` / `samples` / `curves` files, alongside the full unsplit dataset.
+- Added per-project dataset downloads at https://starrydata.github.io/starrydata_datasets/. Each project can now be downloaded separately as `papers` / `samples` / `curves` files, alongside the full unsplit dataset.
 - Compressed all downloads as gzipped CSV (`.csv.gz`) to reduce file size. Load directly with `pandas.read_csv(url, compression="gzip")` or decompress before opening in Excel.
 
 ### 2025/08/22
-- Add figure_name field to curve dataset.
+- Add `figure_name` field to curve dataset.
 
 ### 2024/07/04
-- Excluded datasets with the data type "calculation" in the descriptor from the sample dataset and curve dataset. As of 2024/07/01 12:00:01 UTC+0900 (JST), there were [346 samples](https://github.com/starrydata/notebook/blob/0ab26b17a8046fe480b3649d9faad325688b61e2/check_sample_datatype/check_sample_datatype.ipynb). 
+- Excluded datasets with the data type "calculation" in the descriptor from the sample dataset and curve dataset. As of 2024/07/01 12:00:01 UTC+0900 (JST), there were [346 samples](https://github.com/starrydata/notebook/blob/0ab26b17a8046fe480b3649d9faad325688b61e2/check_sample_datatype/check_sample_datatype.ipynb).
 
 ### 2024/06/26
-- Changed dataset file name prefix from "all" to "starrydata". For example, `all_curves.csv` is now `starrydata_curves.csv`.
+- Changed dataset file name prefix from `all` to `starrydata`. For example, `all_curves.csv` is now `starrydata_curves.csv`.
 - Changed the file extension of the paper dataset from JSON to CSV for availability.
-- Reduced the columns in the paper dataset to only those necessary for citation, reducing the file size from 400MB to about 50MB.
+- Reduced the columns in the paper dataset to only those necessary for citation, reducing the file size from 400 MB to about 50 MB.
 - Added `project_names` and `created_at` to the paper dataset.
 
 ### 2024/06/13
 - The latest datasets are now uploaded to Google Drive.
 
 ### 2024/06/06
-- Fixed the character corruption issue when users open all_samples.csv in certain applications, such as Excel, by adding a BOM.
+- Fixed the character corruption issue when users open `all_samples.csv` in certain applications, such as Excel, by adding a BOM.
 - The upload schedule to Figshare has been changed from daily to monthly.
 
-
 ### 2024/05/22
-- Fixed the incorrect timestamp format in the dataset. For example, corrected "2024-05-17 00:00:01 JST+0900" to "2024-05-17 00:00:01 GMT+0900 (JST)".
-
+- Fixed the incorrect timestamp format in the dataset. For example, corrected `"2024-05-17 00:00:01 JST+0900"` to `"2024-05-17 00:00:01 GMT+0900 (JST)"`.
 
 ### 2024/05/21
 - The values in the XY value list were originally strings enclosed in double quotations. These double quotations were removed for easier analysis.
-- e.g. ["299.8597", "324.8683"] -> [299.8597, 324.8683]
+- e.g. `["299.8597", "324.8683"]` → `[299.8597, 324.8683]`
 
 ### 2024/05/16
 - Added `updated_at`, `created_at`, and `composition_details` to `all_samples.csv`.
 
 ### 2022/12/22
 - The dataset location was changed from this GitHub repository to [Figshare](https://figshare.com/projects/Starrydata_datasets/155129).
-

--- a/docs/index.html
+++ b/docs/index.html
@@ -227,7 +227,6 @@
   const REPO_OWNER = "starrydata";
   const REPO_NAME = "starrydata_datasets";
 
-  const COUNTS_URL = "https://starrydata.github.io/json/counts.json";
   const MANIFEST_URL = "./manifest.json";
   const RELEASE_BASE = `https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/latest/download`;
   const REPO_URL = `https://github.com/${REPO_OWNER}/${REPO_NAME}`;
@@ -296,23 +295,27 @@
     banner.style.display = "block";
   }
 
-  function allDataRow(counts, manifest) {
+  const projectCounts = (entry) => entry?.counts ?? {};
+
+  function allDataRow(manifest) {
+    const totals = manifest?.totals ?? {};
     const driveBtn = `<a class="dl dl-drive" href="${DRIVE_URL}" target="_blank" rel="noopener" title="Always-current full zip mirrored from the official Starrydata Google Drive">Drive zip<span class="sz">always fresh</span></a>`;
     return `
       <tr class="all-data-row">
         <td class="pname">All projects (whole dataset)</td>
-        <td>${fmtNum(counts.papers ?? 0)}</td>
-        <td>${fmtNum(counts.figures ?? 0)}</td>
-        <td>${fmtNum(counts.samples ?? 0)}</td>
-        <td>${fmtNum(counts.curves ?? 0)}</td>
+        <td>${fmtNum(totals.papers ?? 0)}</td>
+        <td>${fmtNum(totals.figures ?? 0)}</td>
+        <td>${fmtNum(totals.samples ?? 0)}</td>
+        <td>${fmtNum(totals.curves ?? 0)}</td>
         <td class="dl-cell"><div class="dl-grid">${allDlButton("papers", manifest)}${allDlButton("samples", manifest)}${allDlButton("curves", manifest)}${driveBtn}</div></td>
       </tr>
     `;
   }
 
-  function renderTotals(counts) {
+  function renderTotals(manifest) {
+    const totals = manifest?.totals ?? {};
     const html = ["papers", "figures", "samples", "curves"].map((k) =>
-      `<div class="stat"><div class="n">${fmtNum(counts[k] ?? 0)}</div><div class="l">${k}</div></div>`
+      `<div class="stat"><div class="n">${fmtNum(totals[k] ?? 0)}</div><div class="l">${k}</div></div>`
     ).join("");
     document.getElementById("totals").innerHTML = html;
   }
@@ -325,11 +328,12 @@
     return `<a class="dl" href="${url}" title="${meta.rows.toLocaleString()} rows, sha256:${meta.sha256.slice(0,12)}…">${kind}<span class="sz">${fmtBytes(meta.bytes)}</span></a>`;
   }
 
-  function renderTable(counts, manifest) {
+  function renderTable(manifest) {
     // Sort by curves desc, but keep Battery-family projects adjacent
     // (anchored to the largest battery's natural position).
     const isBattery = (n) => /Battery/.test(n);
-    const all = Object.entries(counts.projects ?? {});
+    const all = Object.entries(manifest?.projects ?? {})
+      .map(([name, entry]) => [name, projectCounts(entry), entry]);
     const batteryCurves = all.filter(([n]) => isBattery(n)).map(([, c]) => c.curves ?? 0);
     const batteryAnchor = batteryCurves.length ? Math.max(...batteryCurves) : -Infinity;
     const keyOf = ([name, c]) => isBattery(name) ? batteryAnchor : (c.curves ?? 0);
@@ -356,7 +360,7 @@
             <th>Project</th><th>Papers</th><th>Figures</th><th>Samples</th><th>Curves</th><th>Download</th>
           </tr>
         </thead>
-        <tbody>${allDataRow(counts, manifest)}${rows}</tbody>
+        <tbody>${allDataRow(manifest)}${rows}</tbody>
       </table>
     `;
   }
@@ -369,12 +373,9 @@
 
   (async function () {
     try {
-      const [counts, manifest] = await Promise.all([
-        fetchJSON(COUNTS_URL),
-        fetchJSON(MANIFEST_URL).catch(() => ({ projects: {} })),
-      ]);
-      renderTotals(counts);
-      renderTable(counts, manifest);
+      const manifest = await fetchJSON(MANIFEST_URL);
+      renderTotals(manifest);
+      renderTable(manifest);
       document.getElementById("snapshot").textContent = fmtDate(manifest.db_snapshot);
       document.getElementById("generated").textContent = fmtDate(manifest.generated_at);
       checkStaleness(manifest);

--- a/scripts/split.py
+++ b/scripts/split.py
@@ -83,6 +83,16 @@ def split(zip_path: Path, out_dir: Path) -> dict:
     projects_sorted = sorted(all_projects)
     print(f"[info] {len(projects_sorted)} projects detected from curves", file=sys.stderr)
 
+    def _nunique_nonempty(series: pd.Series) -> int:
+        return int(series[series != ""].nunique())
+
+    totals = {
+        "papers": _nunique_nonempty(curves["SID"]),
+        "figures": _nunique_nonempty(curves["figure_id"]) if "figure_id" in curves.columns else 0,
+        "samples": int(len(samples)),
+        "curves": int(len(curves)),
+    }
+
     out_data = out_dir / "data"
     if out_data.exists():
         shutil.rmtree(out_data)
@@ -126,8 +136,15 @@ def split(zip_path: Path, out_dir: Path) -> dict:
                 "bytes": size,
                 "sha256": sha256(fpath),
             }
+        project_figures = _nunique_nonempty(c_sub["figure_id"]) if "figure_id" in c_sub.columns else 0
+        files["counts"] = {
+            "papers": int(len(p_sub)),
+            "figures": project_figures,
+            "samples": int(len(s_sub)),
+            "curves": int(len(c_sub)),
+        }
         print(
-            f"[done] {project:40} papers={len(p_sub):6} samples={len(s_sub):6} curves={len(c_sub):7}",
+            f"[done] {project:40} papers={len(p_sub):6} figures={project_figures:6} samples={len(s_sub):6} curves={len(c_sub):7}",
             file=sys.stderr,
         )
         manifest[project] = files
@@ -136,6 +153,7 @@ def split(zip_path: Path, out_dir: Path) -> dict:
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "db_snapshot": snapshot,
         "source_zip": zip_path.name,
+        "totals": totals,
         "all_data": all_data,
         "projects": manifest,
     }


### PR DESCRIPTION
## Summary
The previous README only listed dataset repositories and a changelog, which no longer matched what this repo actually does (it now hosts the Daily split & release pipeline that publishes per-project CSV.gz files).

Expand to cover:
- What the workflow does (Drive → split → releases → Pages)
- Membership rules (curves-outward, matching the links page)
- Stable download URLs (`/releases/latest/download/...`)
- Python / Excel usage
- The `manifest.json` schema (now also consumed by `starrydata.github.io/links/`)
- Manual re-run instructions
- Failure behavior (auto-opened issue, Drive fallback)

Historical changelog preserved verbatim, with a new 2026/07/17 entry.

## Test plan
- [ ] Render README on GitHub and confirm tables, code blocks, and links all display correctly.
- [ ] Cross-check that filenames and URLs mentioned match the current release contents.